### PR TITLE
Fixes a bug that causes IndexOutOfBoundsExceptions to be thrown due to short ByteBufs

### DIFF
--- a/http/src/main/java/net/mcbrawls/inject/http/HttpInjector.java
+++ b/http/src/main/java/net/mcbrawls/inject/http/HttpInjector.java
@@ -76,6 +76,10 @@ public abstract class HttpInjector extends Injector {
     }
 
     private boolean isRequestMethod(ByteBuf buf, @SuppressWarnings("SameParameterValue") String method) {
+        if (method.length() > buf.capacity()) {
+            return false;
+        }
+
         for (int i = 0; i < method.length(); i++) {
             char charAt = method.charAt(i);
             int byteAt = buf.getUnsignedByte(i);


### PR DESCRIPTION
This issue is the cause of https://github.com/senseiwells/ServerReplay/issues/85.

When the server has the Krypton mod installed ByteBufs with capacity 1 get passed through the pipeline, if there are any HttpInjectors registered this will cause an IOOB exception due to the way that the http method checking code works; it assumes that all ByteBufs' capacity >= the largest http method length.

This PR adds an additional check to ensure that the ByteBuf does indeed have the capacity to check against the http method, before checking each byte.

Here is also the stacktrace for reference:
```
 java.lang.IndexOutOfBoundsException: index: 1, length: 1 (expected: range(0, 1))
	at knot/io.netty.buffer.AbstractByteBuf.checkRangeBounds(AbstractByteBuf.java:1390) ~[netty-buffer-4.1.118.Final.jar:?]
	at knot/io.netty.buffer.AbstractByteBuf.checkIndex0(AbstractByteBuf.java:1397) ~[netty-buffer-4.1.118.Final.jar:?]
	at knot/io.netty.buffer.AbstractByteBuf.checkIndex(AbstractByteBuf.java:1384) ~[netty-buffer-4.1.118.Final.jar:?]
	at knot/io.netty.buffer.AbstractByteBuf.checkIndex(AbstractByteBuf.java:1379) ~[netty-buffer-4.1.118.Final.jar:?]
	at knot/io.netty.buffer.AbstractByteBuf.getByte(AbstractByteBuf.java:355) ~[netty-buffer-4.1.118.Final.jar:?]
	at knot/io.netty.buffer.AbstractByteBuf.getUnsignedByte(AbstractByteBuf.java:368) ~[netty-buffer-4.1.118.Final.jar:?]
	at knot/net.mcbrawls.inject.http.HttpInjector.isRequestMethod(HttpInjector.java:81) ~[http-3.1.3.jar:?]
	at knot/net.mcbrawls.inject.http.HttpInjector.isHttp(HttpInjector.java:91) ~[http-3.1.3.jar:?]
	at knot/net.mcbrawls.inject.http.HttpInjector.isRelevant(HttpInjector.java:39) ~[http-3.1.3.jar:?]
	at knot/net.mcbrawls.inject.api.Injector.write(Injector.java:83) ~[api-3.1.3.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:891) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:875) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:984) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:868) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.handler.timeout.IdleStateHandler.write(IdleStateHandler.java:307) ~[netty-handler-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:891) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:875) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:984) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:868) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:113) ~[netty-codec-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:893) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:875) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:984) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:868) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:863) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.handler.codec.MessageToMessageEncoder.writePromiseCombiner(MessageToMessageEncoder.java:140) ~[netty-codec-4.1.118.Final.jar:?]
	at knot/io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:120) ~[netty-codec-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:893) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:875) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:984) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:868) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:113) ~[netty-codec-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:893) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:875) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:984) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:868) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:113) ~[netty-codec-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:893) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:875) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:984) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:868) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:863) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.handler.codec.MessageToMessageEncoder.writePromiseCombiner(MessageToMessageEncoder.java:140) ~[netty-codec-4.1.118.Final.jar:?]
	at knot/io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:120) ~[netty-codec-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:893) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:875) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:984) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:868) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.ChannelOutboundHandlerAdapter.write(ChannelOutboundHandlerAdapter.java:113) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/net.minecraft.network.Connection$2.write(Connection.java:533) ~[minecraft-merged-8e13ce37dd-1.21.5-loom.mappings.1_21_5.layered+hash.356898441-v2.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:893) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:875) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:984) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:868) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:863) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.DefaultChannelPipeline.write(DefaultChannelPipeline.java:959) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.channel.AbstractChannel.write(AbstractChannel.java:295) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/net.minecraft.network.Connection.doSendPacket(Connection.java:345) ~[minecraft-merged-8e13ce37dd-1.21.5-loom.mappings.1_21_5.layered+hash.356898441-v2.jar:?]
	at knot/net.minecraft.network.Connection.method_52917(Connection.java:340) ~[minecraft-merged-8e13ce37dd-1.21.5-loom.mappings.1_21_5.layered+hash.356898441-v2.jar:?]
	at knot/io.netty.util.concurrent.AbstractEventExecutor.runTask$$$capture(AbstractEventExecutor.java:173) ~[netty-common-4.1.118.Final.jar:?]
	at knot/io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java) ~[netty-common-4.1.118.Final.jar:?]
	at knot/io.netty.util.concurrent.AbstractEventExecutor.safeExecute$$$capture(AbstractEventExecutor.java:166) ~[netty-common-4.1.118.Final.jar:?]
	at knot/io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java) ~[netty-common-4.1.118.Final.jar:?]
	at knot/io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) ~[netty-common-4.1.118.Final.jar:?]
	at knot/io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569) ~[netty-transport-4.1.118.Final.jar:?]
	at knot/io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998) ~[netty-common-4.1.118.Final.jar:?]
	at knot/io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.118.Final.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```